### PR TITLE
fix compile error if RILC_LOG=1

### DIFF
--- a/libril/ril.cpp
+++ b/libril/ril.cpp
@@ -1107,7 +1107,7 @@ dispatchImsGsmSms(Parcel &p, RequestInfo *pRI, uint8_t retry, int32_t messageRef
     rism.messageRef = messageRef;
 
     startRequest;
-    appendPrintBuf("%sformat=%d,", printBuf, rism.format);
+    appendPrintBuf("%sformat=%d,", printBuf, rism.tech);
     if (countStrings == 0) {
         // just some non-null pointer
         pStrings = (char **)alloca(sizeof(char *));
@@ -1552,7 +1552,7 @@ static void dispatchSetInitialAttachApn(Parcel &p, RequestInfo *pRI)
 
     startRequest;
     appendPrintBuf("%sapn=%s, protocol=%s, auth_type=%d, username=%s, password=%s",
-            printBuf, pf.apn, pf.protocol, pf.auth_type, pf.username, pf.password);
+            printBuf, pf.apn, pf.protocol, pf.authtype, pf.username, pf.password);
     closeRequest;
     printRequest(pRI->token, pRI->pCI->requestNumber);
 


### PR DESCRIPTION
When enabling debug output, compile fails, as the structs don't have the fields in question. The same error also exists in hardware/ril/libril since cm-11.0
